### PR TITLE
Add DigitalOcean deployment button

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,40 @@
+name: django-chatbot
+services:
+  - name: web
+    dockerfile_path: Dockerfile
+    run_command: daphne project.asgi:application --port $PORT --bind 0.0.0.0
+    environment_slug: python
+    predeploy:
+      command: python manage.py migrate
+    http_port: 8000
+    envs:
+      - key: DJANGO_SECRET_KEY
+        generate: true
+      - key: DATABASE_URL
+        value: ${db.DATABASE_URL}
+      - key: REDIS_URL
+        value: ${redis.REDIS_URL}
+    instance_count: 1
+    instance_size_slug: basic-xxs
+    routes:
+      - path: /
+  - name: worker
+    dockerfile_path: Dockerfile
+    run_command: celery -A project worker --loglevel info
+    environment_slug: python
+    envs:
+      - key: DJANGO_SECRET_KEY
+        generate: true
+      - key: DATABASE_URL
+        value: ${db.DATABASE_URL}
+      - key: REDIS_URL
+        value: ${redis.REDIS_URL}
+    instance_count: 1
+    instance_size_slug: basic-xxs
+databases:
+  - name: db
+    engine: PG
+    version: "13"
+  - name: redis
+    engine: REDIS
+    version: "6"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Click the button below to deploy the chatbot on Heroku:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
+### DigitalOcean
+You can also deploy the chatbot on [DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform/?refcode=08ce1ee690de).
+
+Click the button below to deploy the chatbot on DigitalOcean:
+
+[![Deploy to DigitalOcean](https://www.deploy.digitalocean.com/button.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/slyapustin/django-chatbot&refcode=08ce1ee690de)
+
 ## Technology Stack
 The chatbot utilizes the following technologies:
 
@@ -28,6 +35,7 @@ The chatbot utilizes the following technologies:
 - [Redis](https://redis.io/): A message broker and cache backend.
 - [Daphne](https://github.com/django/daphne): An HTTP and WebSocket protocol server.
 - [Heroku](https://www.heroku.com): The hosting platform.
+- [DigitalOcean](https://www.digitalocean.com?refcode=08ce1ee690de): An alternative hosting platform.
 
 ## Supported commands
 The chatbot supports the following commands:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Click the button below to deploy the chatbot on Heroku:
 ### DigitalOcean
 You can also deploy the chatbot on [DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform/?refcode=08ce1ee690de).
 
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/slyapustin/django-chatbot/tree/master&refcode=08ce1ee690de)
+
 
 ## Technology Stack
 The chatbot utilizes the following technologies:

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ Click the button below to deploy the chatbot on Heroku:
 ### DigitalOcean
 You can also deploy the chatbot on [DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform/?refcode=08ce1ee690de).
 
-Click the button below to deploy the chatbot on DigitalOcean:
-
-[![Deploy to DigitalOcean](https://www.deploy.digitalocean.com/button.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/slyapustin/django-chatbot&refcode=08ce1ee690de)
 
 ## Technology Stack
 The chatbot utilizes the following technologies:


### PR DESCRIPTION
## Summary
- add a `.do/app.yaml` spec for DigitalOcean App Platform
- update README with new Deploy to DigitalOcean button and note the platform in tech stack
- add DigitalOcean referral code to all DigitalOcean links

## Testing
- `DJANGO_SECRET_KEY=foo REDIS_URL=redis://localhost:6379 DATABASE_URL=postgres://postgres@localhost:5432/postgres python manage.py check`
- `python -m py_compile $(git ls-files '*.py')`
